### PR TITLE
DBにスタンプ帳とスタンプを登録するAPI

### DIFF
--- a/server.deno.js
+++ b/server.deno.js
@@ -36,6 +36,27 @@ serve(async (req) => {
     return new Response(result.data[0].id);
   }
 
+  //スタンプ登録
+  if (req.method === 'POST' && pathname === '/newstamp') {
+    const json=await req.json();
+    const note_id=json.note_id;
+    const title=json.title;
+    const landmark=json.landmark;
+    const category=json.category;
+    const latitude=json.latitude;
+    const longitude=json.longitude;
+    
+    const result=await supabase.from('stamps').insert({
+      note_id:note_id,
+      title:title, 
+      landmark:landmark,
+      category:category,
+      latitude:latitude,
+      longitude:longitude
+    }).select();
+    return new Response()
+  }
+
   return serveDir(req, {
     fsRoot: 'public',
     urlRoot: '',


### PR DESCRIPTION
スタンプ登録は仮実装。画像の扱い方を決めてから着手予定。

スタンプ帳登録
返り値：スタンプ帳ID

```javascript
const date={
    user_id:2, 
    title:'奈良4日目'
};
const params={
    method:'POST', 
    body: JSON.stringify(date)
};
const response=await fetch('/newnote', params);
const node_id=await response.text();
```

スタンプ登録
```javascript
const date={
    note_id:2,
    title:'興福寺', 
    landmark:'興福寺',
    category:'観光',
    latitude:34.682882043343604,
    longitude:135.83222477030412
};
const params={
    method:'POST',
    body: JSON.stringify(date)
};
const response=await fetch('/newstamp', params);
```