### PR TITLE
スタンプを押すのに失敗したときにエラーメッセージが出るように

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -36,9 +36,12 @@ router();
  * @type {HTMLDivElement}
  */
 const overlay = document.querySelector('div.overlay');
-export const closeOverlay = function () {
+export const closeOverlay = function (attachOnClick) {
   overlay.style.display = null;
   overlay.innerHTML = '';
+  if (attachOnClick) {
+    overlay.addEventListener('click', closeOverlay);
+  }
 };
 export const showOverlay = function (child, preventOverlayClose) {
   overlay.style.display = 'grid';

--- a/public/popup/account/account.js
+++ b/public/popup/account/account.js
@@ -71,6 +71,18 @@ export const init = function () {
       ev.target.removeAttribute('disabled');
       overlay.style.display = null;
       overlay.innerHTML = '';
+
+      const todaysNoteIdRes = await fetch(
+        `/noteid/today?user_id=${data.user.id}`
+      );
+      const todaysNoteId = await todaysNoteIdRes.text();
+      if (!todaysNoteId) {
+        document
+          .querySelector('header>button.create-note')
+          .dispatchEvent(new Event('click'));
+        return;
+      }
+      window.localStorage.setItem('note_id', todaysNoteId);
     });
 
   const iconImageSelectButton = document.querySelector(

--- a/public/push/push.css
+++ b/public/push/push.css
@@ -8,6 +8,19 @@ div.push {
   background: var(--color-background);
 }
 
+div.push span.error {
+  width: 100%;
+  margin-top: 16px;
+  padding: 8px;
+  border: 2px solid var(--color-caution);
+  border-radius: 8px;
+  display: none;
+  /* メッセージボックス感がほしいので白背景にします */
+  background-color: white;
+  color: var(--color-caution);
+  font-size: 12px;
+}
+
 div.push h2 {
   width: 100%;
   text-align: left;

--- a/public/push/push.html
+++ b/public/push/push.html
@@ -8,6 +8,7 @@
         accept="image/*"
       />
     </label>
+    <span class="error"></span>
     <div class="inner-push">
     <label>タイトル</label>
     <input

--- a/public/style.css
+++ b/public/style.css
@@ -81,6 +81,9 @@ body > .svg-defs {
 
 main {
   height: calc(100svh - var(--header-footer-height) * 2);
+  overflow-x: hidden;
+  overflow-y: scroll;
+  background-color: var(--color-background)
 }
 
 footer {

--- a/server.deno.js
+++ b/server.deno.js
@@ -164,6 +164,27 @@ serve(async (req) => {
     console.log(res);
     return new Response(JSON.stringify(res));
   }
+
+  // 今日のスタンプ帳idを取得 w/user_id
+  if (pathname === '/noteid/today') {
+    if (req.method === 'GET') {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      console.log(today.toISOString());
+      const user_id = url.searchParams.get('user_id');
+      const res = await supabase
+        .from('notes')
+        .select()
+        .eq('user_id', user_id)
+        .gte('created_at', today.toUTCString())
+        .order('created_at', { ascending: false })
+        .limit(1);
+      if (res.error) return new Response(JSON.stringify(res.error));
+      return new Response(JSON.stringify(res.data[0]?.id));
+    }
+    return new Response('Method not allowed', { status: 405 });
+  }
+
   //スタンプ帳取得 w/note_id
   if (req.method === 'GET' && pathname === '/getnote') {
     const note_id = url.searchParams.get('note_id');


### PR DESCRIPTION
- スタンプを押すのに失敗したときにエラーメッセージが出るようにしました
- これにあたり、note_idをよしなに拾えるようにする必要があったため以下の変更が加わっています
  - GET /noteid/today?user_id=<user_id> で今日の最新のスタンプ帳のidを取れるAPIを実装
  - ログイン時に ↑ のAPIからnote_idを取得するように
  - スタンプ送信時にlocalstorageにnote_idがない場合APIからnote_idを取得できるように
- UIに軽微な変更があります
  - main要素を縦スクロールあり、横スクロールなしに
  - main要素の背景色を設定
- オーバーレイが閉じれなくなる不具合を修正しました

PRタイトル以上の変更が加わっていますが一旦勘弁してください :pray: